### PR TITLE
Update options in meteostickconfigurator so format can be changed

### DIFF
--- a/bin/user/meteostick.py
+++ b/bin/user/meteostick.py
@@ -1294,7 +1294,7 @@ class MeteostickConfigurator(weewx.drivers.AbstractConfigurator):
             "--set-channel", dest="channel", metavar="X", type=int,
             help="set channel: 0-255; default 255")
         parser.add_option(
-            "--set-channel", dest="format", metavar="X", type=int,
+            "--set-format", dest="format", metavar="X", type=int,
             help="set format: 0=raw, 1=machine, 2=human")
 
     def do_options(self, options, parser, config_dict, prompt):


### PR DESCRIPTION
Without this change when the meteostick driver is configured,  "wee_device --help" would crash because of duplicate options
