### PR TITLE
Don't skip counting rain when raw counter is 128

### DIFF
--- a/bin/user/meteostick.py
+++ b/bin/user/meteostick.py
@@ -918,11 +918,10 @@ class Meteostick(object):
                     others wrap around at 255.  When we filter the highest
                     bit, both counter types will wrap at 127.
                     """
-                    if rain_count_raw != 0x80:
-                        rain_count = rain_count_raw & 0x7F  # skip high bit
-                        data['rain_count'] = rain_count
-                        dbg_parse(3, "rain_count_raw=0x%02x value=%s" %
-                                  (rain_count_raw, rain_count))
+                    rain_count = rain_count_raw & 0x7F  # skip high bit
+                    data['rain_count'] = rain_count
+                    dbg_parse(3, "rain_count_raw=0x%02x value=%s" %
+                              (rain_count_raw, rain_count))
                 else:
                     # unknown message type
                     logerr("unknown message type 0x%01x" % message_type)


### PR DESCRIPTION
Reviewing this code only (no empirical testing), I see no reason why rain counting is skipped when the rain counter is 128 (0x80).  The comment above the changed code has a simple solution for cases where the counter wraps at 127 instead of the documented 255, but making a special case for a value of 128 only seems like a bug.  Removing the highest bit in all cases causes wrapping at 127, right?